### PR TITLE
manifest: set app name

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "AS59105",
+  "name": "AS59105 Service Online",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
デフォルトのままでも特に実害はありませんが、このあたりで参照されます。

![IMG_4453](https://user-images.githubusercontent.com/941609/130391791-14ba28fe-75db-4763-a488-4728e3a6c02b.jpg)
![スクリーンショット 2021-08-23 13 42 30](https://user-images.githubusercontent.com/941609/130391665-f57e9648-f75f-43f6-927c-8d6fcc110c0a.png)
![スクリーンショット 2021-08-23 13 42 18](https://user-images.githubusercontent.com/941609/130391660-0f32f136-7972-45f1-b900-3506ab81d2c7.png)
![スクリーンショット 2021-08-23 13 46 09](https://user-images.githubusercontent.com/941609/130391667-cb0c06e9-3bdc-4fee-96e4-e99e599dd60a.png)

