### PR TITLE
feat: Info画面でIX接続情報の表示に対応

### DIFF
--- a/src/interface.ts
+++ b/src/interface.ts
@@ -161,6 +161,9 @@ export interface InfosData {
   noc: string
   noc_ip: string
   term_ip: string
+  ix?: string
+  ix_peer_type?: string
+  ix_vlan_id?: string
   link_v4_our: string
   link_v4_your: string
   link_v6_our: string

--- a/src/pages/Info/Info.tsx
+++ b/src/pages/Info/Info.tsx
@@ -147,18 +147,40 @@ export default function Info() {
                       <th>接続方式</th>
                       <td colSpan={2}>{info.service}</td>
                     </tr>
-                    <tr>
-                      <th>接続NOC</th>
-                      <td colSpan={2}>{info.noc}</td>
-                    </tr>
-                    <tr>
-                      <th>トンネル終端アドレス（貴団体側）</th>
-                      <td colSpan={2}>{info.term_ip}</td>
-                    </tr>
-                    <tr>
-                      <th>トンネル終端アドレス（HomeNOC側）</th>
-                      <td colSpan={2}>{info.noc_ip}</td>
-                    </tr>
+                    {!info.ix && (
+                      <>
+                        <tr>
+                          <th>接続NOC</th>
+                          <td colSpan={2}>{info.noc}</td>
+                        </tr>
+                        <tr>
+                          <th>トンネル終端アドレス（貴団体側）</th>
+                          <td colSpan={2}>{info.term_ip}</td>
+                        </tr>
+                        <tr>
+                          <th>トンネル終端アドレス（HomeNOC側）</th>
+                          <td colSpan={2}>{info.noc_ip}</td>
+                        </tr>
+                      </>
+                    )}
+                    {info.ix && (
+                      <>
+                        <tr>
+                          <th>IX</th>
+                          <td colSpan={2}>{info.ix}</td>
+                        </tr>
+                        <tr>
+                          <th>ピアリングタイプ</th>
+                          <td colSpan={2}>{info.ix_peer_type}</td>
+                        </tr>
+                        {info.ix_peer_type === 'PI/CUG' && info.ix_vlan_id && (
+                          <tr>
+                            <th>VLAN-ID</th>
+                            <td colSpan={2}>{info.ix_vlan_id}</td>
+                          </tr>
+                        )}
+                      </>
+                    )}
                     <tr>
                       <th colSpan={3}>当団体との間の境界アドレス</th>
                     </tr>


### PR DESCRIPTION
## Summary
- IX接続の場合、従来のNOC/トンネル終端アドレスの代わりにIX情報を表示
- `InfosData`インターフェースにIX関連フィールド（`ix`, `ix_peer_type`, `ix_vlan_id`）を追加
- PI/CUGピアリングタイプの場合のみVLAN-IDを表示

## Test plan
- [ ] IX接続がない通常の接続で従来通り表示されることを確認
- [ ] IX接続がある場合にIX名、ピアリングタイプが表示されることを確認
- [ ] PI/CUGタイプの場合にVLAN-IDが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)